### PR TITLE
Exclude last 3 days for cumulative features

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -20,7 +20,17 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install ".[test]"
+        pip install -e ".[test]"
     - name: Running Unit tests
       run: |
-        pytest tests/
+        pytest tests/ --doctest-modules --cov=src --cov-report=xml
+    - name: Code Coverage Summary Report
+      uses: irongut/CodeCoverageSummary@v1.3.0
+      with:
+        filename: coverage.xml
+        badge: true
+        format: 'markdown'
+        output: 'both'
+    
+    - name: Write to Job Summary
+      run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY

--- a/src/noshow/features/appointment_features.py
+++ b/src/noshow/features/appointment_features.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pandas as pd
 
+from noshow.features.cumulative_features import calc_cumulative_features
+
 
 def add_days_since_created(appointments_df: pd.DataFrame) -> pd.DataFrame:
     """Add the number of days since appointment was created
@@ -89,13 +91,11 @@ def add_minutes_early(appointments_df: pd.DataFrame, cutoff: int = 60) -> pd.Dat
     appointments_df.loc[appointments_df["minutes_early"] > cutoff, "minutes_early"] = 0
     appointments_df.loc[appointments_df["minutes_early"] < -cutoff, "minutes_early"] = 0
 
-    appointments_df = appointments_df.sort_index(level="start")
+    appointments_df = calc_cumulative_features(
+        appointments_df, "minutes_early", "prev_minutes_early"
+    )
     appointments_df["prev_minutes_early"] = (
-        appointments_df.groupby(level="pseudo_id")["minutes_early"]
-        .shift(1, fill_value=0)
-        .groupby(level="pseudo_id")
-        .cumsum()
-        / appointments_df["earlier_appointments"]
+        appointments_df["prev_minutes_early"] / appointments_df["earlier_appointments"]
     )
 
     appointments_df["prev_minutes_early"] = appointments_df[

--- a/src/noshow/features/cumulative_features.py
+++ b/src/noshow/features/cumulative_features.py
@@ -1,0 +1,64 @@
+import pandas as pd
+
+
+def calc_cumulative_features(
+    df: pd.DataFrame,
+    column_name: str,
+    feature_name: str,
+    exclude_last: str = "3D",
+    cumfunc: str = "sum",
+) -> pd.DataFrame:
+    """Calculate cumulative features
+
+    This function will calculate cumulative sum or count over features,
+    but exclude the last `exclude_last` observations. This is useful, since
+    some of these observations will not be known at the time of prediction.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The input dataframe, with an index on `pseudo_id` and `start`.
+    column_name : str
+        The column name on which to base the feature.
+    feature_name : str
+        The column name for the newly created feature.
+    exclude_last : str, optional
+        How many recent observations to exclude from calculation,
+        can be anything pandas rolling understands, by default "3D"
+    cumfunc : str, optional
+        The cumulative function to use, by default "sum"
+
+    Returns
+    -------
+    pd.DataFrame
+        The input dataframe with added column containing the new feature.
+
+    Raises
+    ------
+    NotImplementedError
+        Raises a not implemented error in case the cumfunc parameter is not sum or count
+    """
+    if cumfunc not in ("sum", "count"):
+        raise NotImplementedError()
+
+    df = df.sort_index(level="start")
+    grouped_cum_values = df.groupby(level="pseudo_id", sort=False)[column_name]
+    if cumfunc == "sum":
+        total_cum_values = grouped_cum_values.cumsum()
+    else:
+        total_cum_values = grouped_cum_values.cumcount() + 1
+
+    # Exclude last n days of data
+    exclude_last_rolling = (
+        df.reset_index()
+        .set_index("start")
+        .groupby("pseudo_id", sort=False)[column_name]
+        .rolling(exclude_last)
+    )
+    if cumfunc == "sum":
+        exclude_last_values = exclude_last_rolling.sum()
+    else:
+        exclude_last_values = exclude_last_rolling.count()
+
+    df[feature_name] = total_cum_values - exclude_last_values
+    return df

--- a/src/noshow/preprocessing/load_data.py
+++ b/src/noshow/preprocessing/load_data.py
@@ -51,6 +51,9 @@ def process_appointments(appointment_path: Union[str, Path]) -> pd.DataFrame:
 
     appointments_df = appointments_df.set_index(["pseudo_id", "start"])
 
+    # Rolling features can't be calculated on non-unique index
+    appointments_df = appointments_df[~appointments_df.index.duplicated(keep="last")]
+
     return appointments_df
 
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,6 +1,39 @@
 import pandas as pd
 
+from noshow.features.appointment_features import add_minutes_early
+from noshow.features.cumulative_features import calc_cumulative_features
+from noshow.features.no_show_features import prev_no_show_features
 from noshow.features.patient_features import add_patient_features
+
+
+def test_cum_features():
+    test_df = pd.DataFrame(
+        {
+            "pseudo_id": ["1234", "1234", "1234", "5678", "5678", "5678"],
+            "val": [1, 1, 0, 0, 1, 1],
+            "start": pd.to_datetime(
+                [
+                    "2022-01-01 00:00:00",
+                    "2022-01-02 00:00:00",
+                    "2022-01-10 00:00:00",
+                    "2022-01-01 00:00:00",
+                    "2022-01-04 00:00:00",
+                    "2022-01-05 00:00:00",
+                ]
+            ),
+        }
+    ).set_index(["pseudo_id", "start"])
+
+    output_df = calc_cumulative_features(
+        test_df, "val", "sum_out", exclude_last="3D", cumfunc="sum"
+    )
+    output_df = calc_cumulative_features(
+        output_df, "val", "count_out", exclude_last="3D", cumfunc="count"
+    )
+
+    assert output_df.shape == (6, 3)
+    assert output_df["sum_out"].to_list() == [0, 0, 0, 0, 0, 2]
+    assert output_df["count_out"].to_list() == [0, 0, 0, 1, 1, 2]
 
 
 def test_patient_features():
@@ -28,3 +61,61 @@ def test_patient_features():
     # UMC is between 6 and 8 km of Houten
     assert 6 < output_df.loc[("1234", slice(None)), "dist_umcu"].item() < 8
     assert output_df["age"].to_list() == [31, 22]
+
+
+def test_no_show_features():
+    test_df = pd.DataFrame(
+        {
+            "pseudo_id": ["1234", "1234", "5678", "5678"],
+            "no_show": ["no_show", "no_show", "no_show", "show"],
+            "start": pd.to_datetime(
+                [
+                    "2022-01-01 00:00:00",
+                    "2022-01-02 00:00:00",
+                    "2022-01-01 00:00:00",
+                    "2022-01-04 00:00:00",
+                ]
+            ),
+        }
+    ).set_index(["pseudo_id", "start"])
+
+    output_df = prev_no_show_features(test_df)
+
+    assert output_df.shape == (4, 4)
+    assert output_df["prev_no_show"].to_list() == [0, 0, 0, 1]
+    assert output_df["prev_no_show_perc"].to_list() == [0.0, 0.0, 0.0, 1.0]
+    assert output_df["earlier_appointments"].to_list() == [0, 0, 0, 1]
+
+
+def test_minutes_early():
+    test_df = pd.DataFrame(
+        {
+            "pseudo_id": ["1234", "1234", "1234", "5678", "5678", "5678"],
+            "earlier_appointments": [0, 0, 2, 0, 1, 1],
+            "gearriveerd": pd.to_datetime(
+                [
+                    "2022-01-01 00:04:00",
+                    "2022-01-02 00:02:00",
+                    "2022-01-10 00:01:00",
+                    "2021-12-31 23:55:00",
+                    "2022-01-04 00:01:00",
+                    "2022-01-05 00:00:00",
+                ]
+            ),
+            "start": pd.to_datetime(
+                [
+                    "2022-01-01 00:00:00",
+                    "2022-01-02 00:00:00",
+                    "2022-01-10 00:00:00",
+                    "2022-01-01 00:00:00",
+                    "2022-01-04 00:00:00",
+                    "2022-01-05 00:00:00",
+                ]
+            ),
+        }
+    ).set_index(["pseudo_id", "start"])
+
+    output_df = add_minutes_early(test_df)
+
+    assert output_df.shape == (6, 4)
+    assert output_df["prev_minutes_early"].to_list() == [0.0, 0.0, 0.0, 5.0, 5.0, -3.0]


### PR DESCRIPTION
Cumulative features like previous no-shows and average minutes early are now calculated on the previous appointments up to 3 days before the current appointment, to beter simulate the situation when deployed. Also included unit tests for the changed functions.

Closes: #11 
Closes: #2 