### PR TITLE
Filter on booked appointments during pred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2023-09-29
+
+### Fixed
+- When predicting with a given start-date, predictions are only made on appointments with status 'booked'. This prevents appointments with status 'cancelled'/'proposed'/'waiting_list' from showing up in the dashboard. 
+
 ## [1.0.0] - 2023-09-26
 This is the first full release of the no-show project. This release will be used during the pilot-phase and
 shared as an open-source repo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "noshow"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   { name="Ruben Peters", email="r.peters-7@umcutrecht.nl" },
   { name="Ingmar Loohuis", email="i.p.loohuis-2@umcutrecht.nl" }

--- a/src/noshow/model/predict.py
+++ b/src/noshow/model/predict.py
@@ -20,9 +20,32 @@ def create_prediction(
     prediction_start_date: Optional[str] = None,
     add_sensitive_info: bool = False,
 ) -> pd.DataFrame:
+    """Create predictions using a pretrained model
+
+    Parameters
+    ----------
+    model : Any
+        A sklearn model (that implements the predict_proba function)
+    appointments_df : pd.DataFrame
+        Dataframe containing cleaned appointments data
+    all_postal_codes : pd.DataFrame
+        Dataframe containing postalcodes
+    prediction_start_date : Optional[str], optional
+        Start date for the predictions, if given will only predict appointments
+        that have status 'booked' and occur after the start date, by default None
+    add_sensitive_info : bool, optional
+        If sensitive data should be added to the predictions
+        for use in the api, by default False
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe containing the predictions and optionaly sensitive info
+    """
     featuretable = create_features(appointments_df, all_postal_codes)
 
     if prediction_start_date:
+        featuretable = featuretable.loc[featuretable["status"] == "booked"]
         featuretable = featuretable.sort_index().loc[
             (slice(None), slice(prediction_start_date, None)), :
         ]


### PR DESCRIPTION
Haven't encountered this going wrong yet, but in theory we could be making predictions on appointments that don't have status booked (like cancelled/proposed/waiting-list) and those would show up in the dashboard, therefore we should only make predictions on appointments that actually have status booked