### PR TITLE
Fix full name being None bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.10] - 2024-07-24
+
+### Fixed
+- Fixed a bug where when the full name of a patient is None, the predict endpoint crashes
+
 ## [1.2.9] - 2024-07-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "noshow"
-version = "1.2.9"
+version = "1.2.10"
 authors = [
   { name="Ruben Peters", email="r.peters-7@umcutrecht.nl" },
   { name="Eric Wolters", email="e.j.wolters-4@umcutrecht.nl" }

--- a/src/noshow/api/app.py
+++ b/src/noshow/api/app.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from datetime import datetime
 from pathlib import Path
@@ -32,6 +33,8 @@ from noshow.preprocessing.load_data import (
     process_postal_codes,
 )
 from noshow.preprocessing.utils import add_working_days
+
+logger = logging.getLogger(__name__)
 
 load_dotenv()
 
@@ -156,6 +159,13 @@ async def predict(
         apisensitive = db.get(ApiSensitiveInfo, row["pseudo_id"])
 
         if not apisensitive:
+            if row["name_text"] is None:
+                row["name_text"] = ""
+                logger.warning(
+                    f"Patient {row['pseudo_id']} has no name_text, "
+                    "replacing with empty string"
+                )
+
             apisensitive = ApiSensitiveInfo(
                 patient_id=row["pseudo_id"],
                 full_name=row["name_text"],


### PR DESCRIPTION
The full name of a patient can apparently be None, causing a SQLalchemy error and crashing the predict endpoint. This PR fixes this bug. 