### PR TITLE
Add both agenda name and teleQ name to dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2024-10-10
+
+### Fixed
+- Calling dash now both shows main agenda name and TeleQ name to prevent confusion when TeleQ name does not clearly indicate for which clinic the appointment is
+
+### Changed
+- clinic phone number is still stored in the database, but no longer shown in the calling dash, since any rescheduling needs to be done through TeleQ
+
 ## [1.4.0] - 2024-10-08
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "noshow"
-version = "1.4.0"
+version = "1.4.1"
 authors = [
   { name="Ruben Peters", email="r.peters-7@umcutrecht.nl" },
   { name="Eric Wolters", email="e.j.wolters-4@umcutrecht.nl" }

--- a/run/calling_dash.py
+++ b/run/calling_dash.py
@@ -99,8 +99,8 @@ def main():
                 ApiPrediction.id,
                 ApiPrediction.start_time,
                 ApiPrediction.clinic_name,
+                ApiPrediction.clinic_teleq_unit,
                 ApiPrediction.clinic_reception,
-                ApiPrediction.clinic_phone_number,
                 ApiCallResponse.call_status,
                 ApiRequest.timestamp,
             )

--- a/src/noshow/api/app.py
+++ b/src/noshow/api/app.py
@@ -213,11 +213,12 @@ async def predict(
             apiprediction.prediction = row["prediction"]
             apiprediction.start_time = row["start"]
             apiprediction.request_relation = apirequest
-            apiprediction.clinic_name = CLINIC_CONFIG[row["clinic"]].teleq_name
+            apiprediction.clinic_name = row["hoofdagenda"]
             apiprediction.clinic_reception = row["description"]
             apiprediction.clinic_phone_number = CLINIC_CONFIG[
                 row["clinic"]
             ].phone_number
+            apiprediction.clinic_teleq_unit = CLINIC_CONFIG[row["clinic"]].teleq_name
             apiprediction.active = True
 
         db.merge(apisensitive)

--- a/src/noshow/api/app.py
+++ b/src/noshow/api/app.py
@@ -202,9 +202,10 @@ async def predict(
                 start_time=row["start"],
                 request_relation=apirequest,
                 patient_relation=apipatient,
-                clinic_name=CLINIC_CONFIG[row["clinic"]].teleq_name,
+                clinic_name=row["hoofdagenda"],
                 clinic_reception=row["description"],
                 clinic_phone_number=CLINIC_CONFIG[row["clinic"]].phone_number,
+                clinic_teleq_unit=CLINIC_CONFIG[row["clinic"]].teleq_name,
                 active=True,
             )
         else:

--- a/src/noshow/database/models.py
+++ b/src/noshow/database/models.py
@@ -52,6 +52,7 @@ class ApiPrediction(Base):
     clinic_name: Mapped[str]
     clinic_reception: Mapped[str]
     clinic_phone_number: Mapped[str]
+    clinic_teleq_unit: Mapped[str] = mapped_column(String, nullable=True)
     request_id: Mapped[int] = mapped_column(
         Integer, ForeignKey(ApiRequest.id), init=False
     )


### PR DESCRIPTION
### Fixed
- Calling dash now both shows main agenda name and TeleQ name to prevent confusion when TeleQ name does not clearly indicate for which clinic the appointment is

### Changed
- clinic phone number is still stored in the database, but no longer shown in the calling dash, since any rescheduling needs to be done through TeleQ

Closes: #132 

See: https://rsc.ds.umcutrecht.nl/content/a4f403a9-8d43-4757-8caf-c78fb0669dfc