### PR TITLE
Filter appointments and improve training pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2025-06-25
+
+### Changed
+- Updated the data loading for appointments to filter out appointments that are both finished and no-show (due to moving the original appointment for example) and filter out appointments that were cancelled on time (no no-show).
+
 ## [2.1.0] - 2025-06-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated the data loading for appointments to filter out appointments that are both finished and no-show (due to moving the original appointment for example) and filter out appointments that were cancelled on time (no no-show).
+- Improved the train pipeline script and made it available as a CLI command using click.
+- Improved the loading function for appointments to use the pyarrow backend, which results in faster loading times and better type inference.
+- Updated requirements
 
 ## [2.1.0] - 2025-06-18
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ We welcome issues or pull requests! The easiest way to use this repo in your own
 To install the noshow package use:
 
 ```bash
-pip install -e .
+pip install -r requirements.txt
 ```
 
 Or better use a package manager like [uv](https://docs.astral.sh/uv/), a modern Python package manager that simplifies dependency management and ensures reproducibility:
@@ -35,11 +35,10 @@ uv sync
 
 ## Run pipelines
 
-The no-show code uses DVC pipelines. To run the feature-building and model stages, use:
+To run the entire pipeline from data export to model training, you can use the `train_no_show` command (or `python src/noshow/train_pipeline.py`):
 
 ```bash
-dvc pull
-dvc exp run
+train_no_show --skip-export  # skip the export step if you already have the data
 ```
 
 For more information on data used, check the dataset card [here](data/dataset_card.md)

--- a/data/raw/poliafspraken_no_show.csv.dvc
+++ b/data/raw/poliafspraken_no_show.csv.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: e26b95b5e8f377fb3aa7de1a1041c17b
-  size: 792227689
+- md5: c7548b40535ed7332d92005b0a0d0d61
+  size: 792802394
   path: poliafspraken_no_show.csv
   hash: md5

--- a/output/models/no_show_model_cv.pickle.dvc
+++ b/output/models/no_show_model_cv.pickle.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 1304c356629555a161c061edfb59bc44
-  size: 1956785
+- md5: d0f7d5770ed12a65dd22342d145c735c
+  size: 1951596
   hash: md5
   path: no_show_model_cv.pickle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dependencies =[
     "rich>=14.0.0",
 ]
 
+[project.scripts]
+train_no_show = "noshow.train_pipeline:train_pipeline"
+
 [dependency-groups]
 dev = [
     "ipykernel>=6.29.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "noshow"
-version = "2.1.0"
+version = "2.1.1"
 authors = [
   { name="Ruben Peters", email="r.peters-7@umcutrecht.nl" },
   { name="Eric Wolters", email="e.j.wolters-4@umcutrecht.nl" },

--- a/requirements.txt
+++ b/requirements.txt
@@ -119,13 +119,13 @@ matplotlib==3.10.3
     #   seaborn
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.1.0
+mlflow==3.1.1
     # via noshow
-mlflow-skinny==3.1.0
+mlflow-skinny==3.1.1
     # via mlflow
-narwhals==1.43.0
+narwhals==1.44.0
     # via altair
-numpy==2.3.0
+numpy==2.3.1
     # via
     #   contourpy
     #   matplotlib
@@ -189,9 +189,9 @@ pydantic-core==2.33.2
     # via pydantic
 pydeck==0.9.1
     # via streamlit
-pygments==2.19.1
+pygments==2.19.2
     # via rich
-pymssql==2.3.4
+pymssql==2.3.5
     # via noshow
 pyparsing==3.2.3
     # via matplotlib
@@ -201,7 +201,7 @@ python-dateutil==2.9.0.post0
     #   holidays
     #   matplotlib
     #   pandas
-python-dotenv==1.1.0
+python-dotenv==1.1.1
     # via noshow
 pytz==2025.2
     # via pandas
@@ -235,7 +235,7 @@ scikit-learn==1.7.0
     #   mlflow
     #   noshow
     #   relplot
-scipy==1.15.3
+scipy==1.16.0
     # via
     #   mlflow
     #   relplot
@@ -288,7 +288,7 @@ typing-inspection==0.4.1
     # via pydantic
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via
     #   docker
     #   requests

--- a/src/noshow/preprocessing/load_data.py
+++ b/src/noshow/preprocessing/load_data.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import date
 from pathlib import Path
 from typing import Dict, List, Union
@@ -6,6 +7,8 @@ import pandas as pd
 
 from noshow.api.pydantic_models import Appointment
 from noshow.config import NO_SHOW_CODES, ClinicConfig
+
+logger = logging.getLogger(__name__)
 
 
 def load_appointment_pydantic(input: List[Appointment]) -> pd.DataFrame:
@@ -95,6 +98,29 @@ def process_appointments(
     appointments_df.loc[
         appointments_df["mutationReason_code"].isin(NO_SHOW_CODES), "no_show"
     ] = "no_show"
+
+    # Appointments that have status finished but mutation No-Show could have
+    # been moved and need to be filtered out
+    no_show_finished_mask = (appointments_df["no_show"] == "no_show") & (
+        appointments_df["status"] == "finished"
+    )
+    if no_show_finished_mask.any():
+        appointments_df = appointments_df.loc[~no_show_finished_mask]
+        logger.warning(
+            f"Filtered out {no_show_finished_mask.sum()} no-show "
+            "appointments with status 'finished'."
+        )
+
+    # Remove appointments that are cancelled for other reasons than no-show
+    cancelled_mask = (appointments_df["status"] == "cancelled") & (
+        appointments_df["no_show"] != "no_show"
+    )
+    if cancelled_mask.any():
+        appointments_df = appointments_df.loc[~cancelled_mask]
+        logger.info(
+            f"Filtered out {cancelled_mask.sum()} cancelled appointments "
+            "that are not no-shows."
+        )
 
     # Some patients have multiple postal codes
     appointments_df = appointments_df.drop_duplicates(

--- a/src/noshow/preprocessing/load_data.py
+++ b/src/noshow/preprocessing/load_data.py
@@ -52,19 +52,7 @@ def load_appointment_csv(csv_path: Union[str, Path]) -> pd.DataFrame:
     """
     appointments_df = pd.read_csv(
         csv_path,
-        parse_dates=["created"],
-        date_format="ISO8601",
-        dtype={"specialty_code": "object"},  # Avoids Dtype Mixed warning
-    )
-
-    appointments_df["start"] = pd.to_datetime(
-        appointments_df["start"], errors="coerce", format="ISO8601"
-    )
-    appointments_df["end"] = pd.to_datetime(
-        appointments_df["end"], errors="coerce", format="ISO8601"
-    )
-    appointments_df["gearriveerd"] = pd.to_datetime(
-        appointments_df["gearriveerd"], errors="coerce", format="ISO8601"
+        engine="pyarrow",
     )
 
     return appointments_df

--- a/src/noshow/train_pipeline.py
+++ b/src/noshow/train_pipeline.py
@@ -4,6 +4,7 @@ the model."""
 import logging
 from pathlib import Path
 
+import click
 from dotenv import load_dotenv
 from sklearn.ensemble import HistGradientBoostingClassifier
 
@@ -19,19 +20,22 @@ from noshow.preprocessing.load_data import (
 
 logger = logging.getLogger(__name__)
 
-if __name__ == "__main__":
+
+@click.command()
+@click.option("--skip-export", is_flag=True, help="Skip data export from the database.")
+def train_pipeline(skip_export: bool) -> None:
+    """Main function to run the training pipeline for the no-show model."""
     load_dotenv(override=True)
     setup_root_logger()
 
-    data_path = Path(__file__).parents[1] / "data" / "raw"
-    output_path = Path(__file__).parents[1] / "data" / "processed"
-    model_path = Path(__file__).parents[1] / "output" / "models"
+    if not skip_export:
+        logger.info("Starting data export...")
+        export_data()
 
-    # Export the data from the database
-    logger.info("Starting data export...")
-    export_data()
+    data_path = Path(__file__).parents[2] / "data" / "raw"
+    output_path = Path(__file__).parents[2] / "data" / "processed"
+    model_path = Path(__file__).parents[2] / "output" / "models"
 
-    # Load the exported data
     logger.info("Processing data...")
     appointments_df = load_appointment_csv(data_path / "poliafspraken_no_show.csv")
     appointments_df = process_appointments(appointments_df, CLINIC_CONFIG)
@@ -58,3 +62,7 @@ if __name__ == "__main__":
             "learning_rate": [0.01, 0.05, 0.1],
         },
     )
+
+
+if __name__ == "__main__":
+    train_pipeline()


### PR DESCRIPTION
### Changed
- Updated the data loading for appointments to filter out appointments that are both finished and no-show (due to moving the original appointment for example) and filter out appointments that were cancelled on time (no no-show).
- Improved the train pipeline script and made it available as a CLI command using click.
- Improved the loading function for appointments to use the pyarrow backend, which results in faster loading times and better type inference.
- Updated requirements

see: https://rsc.ds.umcutrecht.nl/content/a4f403a9-8d43-4757-8caf-c78fb0669dfc

Closes: #174 
Closes: #191 